### PR TITLE
Service worker

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -6,7 +6,10 @@ self.addEventListener('fetch', function (event) {
                 console.log("fetch completed: " + event.request.url, networkResponse);
                 if (networkResponse) {
                     console.debug("updated cached page: " + event.request.url, networkResponse);
-                    cache.put(event.request, networkResponse.clone());
+                    if (event.request.method === 'GET' && event.request.url.includes(event.request.referrer)) {
+                        console.error(event.request);
+                        cache.put(event.request, networkResponse.clone());
+                    }
                 }
                 return networkResponse;
             }, function (event) {
@@ -44,9 +47,6 @@ self.addEventListener('fetch', function (event) {
                             '/js/vendors/jquery.min.js',
                             '/js/vendors/owl.carousel.min.js',
                             '/js/vendors/swiper.min.js',
-                            'https://fonts.googleapis.com/css?family=Google+Sans:400,500,700|Material+Icons',
-                            'https://www.google-analytics.com/analytics.js',
-                            'https://use.fontawesome.com/releases/v5.2.80/css/all.css',
                             '/service-worker.js',
                             '/manifest.json',
                         ]);

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,8 +6,7 @@ self.addEventListener('fetch', function (event) {
                 console.log("fetch completed: " + event.request.url, networkResponse);
                 if (networkResponse) {
                     console.debug("updated cached page: " + event.request.url, networkResponse);
-                    if (event.request.method === 'GET' && event.request.url.includes(event.request.referrer)) {
-                        console.error(event.request);
+                    if (event.request.method === 'GET' && networkResponse.type === 'basic') {
                         cache.put(event.request, networkResponse.clone());
                     }
                 }


### PR DESCRIPTION
Fixes #39 

Prevent caching of non GET responses and [opaque/cors responses](https://developers.google.com/web/tools/workbox/guides/handle-third-party-requests)


https://cloudfour.com/thinks/when-7-kb-equals-7-mb/

Your storage was taking above 100mb, this PR reduces it to 1.5mb