### PR TITLE
Team: complete redesign of team section to have cards with circular image lead fixes#38

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1232,15 +1232,15 @@ hr{
   color: #637282;
 }
 
-.footer-widget .social-list__inline li {
+.social-list__inline li {
   margin-right: 15px;
 }
 
-.footer-widget .social-list__inline li:last-of-type {
+.social-list__inline li:last-of-type {
   margin: 0;
 }
 
-.footer-widget .social-list__inline li a {
+.social-list__inline li a {
   color: #1B2733;
   font-size: 24px;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -1075,75 +1075,130 @@ hr{
   margin-top: 5px;
 }
 
-.team-slide-inner {
-  height: 100%  ;
+/*carousel styling*/
+@media (min-width: 768px) {
+
+    /* show 3 items */
+    .carouselPrograms .carousel-inner .active,
+    .carouselPrograms .carousel-inner .active + .carousel-item,
+    .carouselPrograms .carousel-inner .active + .carousel-item + .carousel-item {
+        display: block;
+    }
+
+    .carouselPrograms .carousel-inner .carousel-item.active:not(.carousel-item-right):not(.carousel-item-left),
+    .carouselPrograms .carousel-inner .carousel-item.active:not(.carousel-item-right):not(.carousel-item-left) + .carousel-item,
+    .carouselPrograms .carousel-inner .carousel-item.active:not(.carousel-item-right):not(.carousel-item-left) + .carousel-item + .carousel-item {
+        transition: none;
+    }
+
+    .carouselPrograms .carousel-inner .carousel-item-next,
+    .carouselPrograms .carousel-inner .carousel-item-prev {
+        position: relative;
+        transform: translate3d(0, 0, 0);
+    }
+
+    .carouselPrograms .carousel-inner .active.carousel-item + .carousel-item + .carousel-item + .carousel-item {
+        position: absolute;
+        top: 0;
+        right: -33.333%;
+        z-index: -1;
+        display: block;
+        visibility: visible;
+    }
+
+    /* left or forward direction */
+    .carouselPrograms .active.carousel-item-left + .carousel-item-next.carousel-item-left,
+    .carouselPrograms .carousel-item-next.carousel-item-left + .carousel-item,
+    .carouselPrograms .carousel-item-next.carousel-item-left + .carousel-item + .carousel-item,
+    .carouselPrograms .carousel-item-next.carousel-item-left + .carousel-item + .carousel-item + .carousel-item {
+        position: relative;
+        transform: translate3d(-100%, 0, 0);
+        visibility: visible;
+    }
+
+    /* farthest right hidden item must be abso position for animations */
+    .carouselPrograms .carousel-inner .carousel-item-prev.carousel-item-right {
+        position: absolute;
+        top: 0;
+        left: 0%;
+        z-index: -1;
+        display: block;
+        visibility: visible;
+    }
+
+    /* right or prev direction */
+    .carouselPrograms .active.carousel-item-right + .carousel-item-prev.carousel-item-right,
+    .carouselPrograms .carousel-item-prev.carousel-item-right + .carousel-item,
+    .carouselPrograms .carousel-item-prev.carousel-item-right + .carousel-item + .carousel-item,
+    .carouselPrograms .carousel-item-prev.carousel-item-right + .carousel-item + .carousel-item + .carousel-item {
+        position: relative;
+        transform: translate3d(100%, 0, 0);
+        visibility: visible;
+        display: block;
+        visibility: visible;
+    }
 }
 
-.team-slider__indicators {
-  list-style-type: none;
-  padding: 0;
-  margin: 0;
+/*end carousel styling*/
+
+/*team card stying*/
+.card.hovercard .cardheader {
+    background: #3BC1FD;
+    background-size: cover;
+    height: 135px;
 }
 
-.team-slider__indicators .owl-dot {
-  border-radius: 1px  ;
-  width: 4px;
-  height: 50px;
-  background: rgba(255, 255, 255, 0.1);
-  margin-left: auto;
-  margin-right: auto;
-  cursor: pointer;
+.card.hovercard .avatar {
+    position: relative;
+    top: -50px;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: -50px;
 }
 
-.team-slider__indicators .owl-dot.active {
-  background: #fff;
+.card.hovercard .avatar img {
+    width: 100px;
+    height: 100px;
+    max-width: 100px;
+    max-height: 100px;
+    -webkit-border-radius: 50%;
+    -moz-border-radius: 50%;
+    border-radius: 50%;
+    border: 5px solid rgba(255,255,255,0.5);
 }
 
-.team-item .btn-light {
-  position: absolute;
-  bottom: 20px;
-  right: 20px;
-  -webkit-transition: all .5s ease-in-out;
-  transition: all .5s ease-in-out;
+.card.hovercard .info {
+    padding: 4px 8px 10px;
+    text-align: center;
+
 }
 
-.team-item .btn-light .u-icon {
-  background: #3BC1FD;
-  margin-left: 10px;
+.card.hovercard .info .title h5 {
+    margin-bottom: 4px;
+    font-size: 24px;
+    line-height: 1;
+    color: #262626;
 }
-
-.team-item .btn-light:hover {
-  -webkit-box-shadow: -5px 5px #3BC1FD;
-          box-shadow: -5px 5px #3BC1FD;
-  -webkit-transform: translate(1px, -1px);
-          transform: translate(1px, -1px);
+.card.hovercard .info .title p {
+  color: #262626;
 }
-
-.team-item__context {
-  font-weight: 300;
-  margin-bottom: 40px;
+.card.hovercard .info .desc {
+    overflow: hidden;
+    font-size: 14px;
+    line-height: 20px;
+    color: #737373;
+    text-overflow: ellipsis;
 }
-
-.team-item__context p {
-  font-size: 22px;
+.card.hovercard .bottom{
+    padding: 0 20px;
+    margin-bottom: 17px;
+    margin-left: auto;
+    margin-right: auto;
 }
-
-.team-item__context img {
-  margin-bottom: 20px;
+.card.hovercard .bottom ul li a i{
+  color: #3BC1FD;
 }
-
-.team-item__thumb {
-  position: relative;
-}
-
-.team-item__image {
-  border-radius: 50%;
-  overflow: hidden;
-  width: 260px;
-  height: 260px;
-  margin-left: auto;
-  margin-right: auto;
-}
+/*end team card stying*/
 .section-faq .card {
   border: 0;
   margin-bottom: 30px;

--- a/index.html
+++ b/index.html
@@ -478,152 +478,296 @@
             <h2 class="section-title">Meet The DSC Team</h2>
             <span class="text-light">Passionate students and faculty staff driving the success of the program.</span>
         </header>
-        <div class="row flex-column-reverse flex-lg-row-reverse align-items-sm-center">
-            <div class="col-md-1">
-                <ul class="dots team-slider__indicators">
-                    <li class="owl-dot"></li>
-                    <li class="owl-dot"></li>
-                    <li class="owl-dot"></li>
-                    <li class="owl-dot"></li>
-                    <li class="owl-dot"></li>
-                </ul>
-            </div>
-            <div class="col-md-11">
-                <div class="owl-carousel team-slider">
+         <div class="container-fluid">
+          <div id="carouselExample" class="carouselPrograms carousel slide" data-ride="carousel" data-interval="false">
+            <div class="carousel-inner row w-100 mx-auto" role="listbox">
+                
+          <div class="carousel-item col-md-4 col-15 active">
+              <div class="card event-card">
+                <div class="card hovercard">
+                    <div class="cardheader">
 
-                    <blockquote class="team-item">
-                        <div class="row align-items-center flex-column-reverse flex-md-row justify-content-sm-center">
-                            <div class="col-12 col-md-4">
-                                <div class="team-item__thumb">
-                                    <div class="team-item__image">
-                                        <img data-src="images/assets/team/avatar.png" alt="Lead headshot">
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-md-8">
-                                <div class="team-content">
-                                    <div class="team-item__context">
-                                        <p class="vanish"><i class="fab fa-twitter"></i> @twitterhandle</p>
-                                        <p class="vanish">A highly-motivated mobile and web developer with an acquired
-                                            taste for
-                                            elegant design, an open source hobbyist & a community mentor keen to inspire
-                                            change-makers.</p>
-                                    </div>
-                                    <div class="team-meta">
-                                        <h5>Name goes here</h5>
-                                        <p>Lead Organizer & 4th Year Student.</p>
-                                    </div>
-                                </div>
-                            </div>
+                    </div>
+                    <div class="avatar">
+                        <img alt="" src="images/assets/team/avatar.png" alt="shell lead avatar">
+                    </div>
+                    <div class="info">
+                        <div class="title">
+                          <h5>Name goes here</h5>
+                          <p>Lead Organizer</p>
                         </div>
-                    </blockquote>
-                    <blockquote class="team-item">
-                        <div class="row align-items-center flex-column-reverse flex-md-row justify-content-sm-center">
-                            <div class="col-12 col-md-4">
-                                <div class="team-item__thumb">
-                                    <div class="team-item__image">
-                                        <img data-src="images/assets/team/avatar.png" alt="co-lead headshot">
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-md-8">
-                                <div class="team-content">
-                                    <div class="team-item__context">
-                                        <p class="vanish"><i class="fab fa-twitter"></i> @twitterhandle</p>
-                                        <p class="vanish">A highly-motivated mobile and web developer with an acquired
-                                            taste for
-                                            elegant design, an open source hobbyist & a community mentor keen to inspire
-                                            change-makers.</p>
-                                    </div>
-                                    <div class="team-meta">
-                                        <h5>Name goes here</h5>
-                                        <p>Assistant organizer & 3rd Year Student.</p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </blockquote>
-                    <blockquote class="team-item">
-                        <div class="row align-items-center flex-column-reverse flex-md-row justify-content-sm-center">
-                            <div class="col-12 col-md-4">
-                                <div class="team-item__thumb">
-                                    <div class="team-item__image">
-                                        <img data-src="images/assets/team/avatar.png" alt="co-lead headshot">
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-md-8">
-                                <div class="team-content">
-                                    <div class="team-item__context">
-                                        <p class="vanish"><i class="fab fa-twitter"></i> @twitterhandle</p>
-                                        <p class="vanish">A highly-motivated mobile and web developer with an acquired
-                                            taste for
-                                            elegant design, an open source hobbyist & a community mentor keen to inspire
-                                            change-makers.</p>
-                                    </div>
-                                    <div class="team-meta">
-                                        <h5>Name goes here</h5>
-                                        <p>Co-organizer & 1st Year Student.</p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </blockquote>
-                    <blockquote class="team-item ">
-                        <div class="row align-items-center flex-column-reverse flex-md-row justify-content-sm-center">
-                            <div class="col-12 col-md-4">
-                                <div class="team-item__thumb">
-                                    <div class="team-item__image">
-                                        <img data-src="images/assets/team/avatar.png" alt="co-lead headshot">
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-md-8">
-                                <div class="team-content">
-                                    <div class="team-item__context">
-                                        <p class="vanish"><i class="fab fa-twitter"></i> @twitterhandle</p>
-                                        <p class="vanish">My areas of specialization include:- Concurrency
-                                            control,Bioinformatics, ICT
-                                            integration,knowledge based systems, IoT and e-learning.</p>
-                                    </div>
-                                    <div class="team-meta">
-                                        <h5>Name goes here</h5>
-                                        <p>Volunteer & 2nd Year Student.</p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </blockquote>
+                        <div class="desc">Mobile and Web developer</div>
+                        <div class="desc">Open source enthusiast</div>
+                        <div class="desc">Community mentor</div>
+                    </div>
+                    <div class="bottom">
+                    <ul class="social-list__inline mt-10">
+                      <li>
+                          <a href="https://twitter.com/ProfileName">
+                              <i class="fab fa-twitter"></i>
+                          </a>
+                      </li>
+                      <li>
+                          <a href="https://github.com/ProfileName">
+                              <i class="fab fa-github"></i>
+                          </a>
+                      </li>
+                      <li>
+                          <a href="https://www.facebook.com/ProfileName">
+                              <i class="fab fa-facebook"></i>
+                          </a>
+                      </li>
+                      <li>
+                          <a href="https://www.linkedin.com/in/ProfileName">
+                              <i class="fab fa-linkedin"></i>
+                          </a>
+                      </li>
+                    </ul>
+                  </div>
+                  </div>
+              </div>
+          </div>
 
-                    <blockquote class="team-item">
-                        <div class="row align-items-center flex-column-reverse flex-md-row justify-content-sm-center">
-                            <div class="col-12 col-md-4">
-                                <div class="team-item__thumb">
-                                    <div class="team-item__image">
-                                        <img data-src="images/assets/team/avatar.png" alt="co-lead headshot">
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-md-8">
-                                <div class="team-content">
-                                    <div class="team-item__context">
-                                        <p class="vanish"><i class="fab fa-twitter"></i> @twitterhandle</p>
-                                        <p class="vanish">Learning how to code has given me problem-solving skills and a
-                                            way to communicate with others on a technical level. I am learning how to solve
-                                            using different programming languages and such. I love reading extensively.
-                                            Interact with different people and share experiences.</p>
-                                    </div>
-                                    <div class="team-meta">
-                                        <h5>Name goes here</h5>
-                                        <p>DSC Faculty Adviser</p>
-                                    </div>
-                                </div>
-                            </div>
+          <div class="carousel-item col-md-4 col-15">
+              <div class="card event-card">
+                <div class="card hovercard">
+                    <div class="cardheader">
+
+                    </div>
+                    <div class="avatar">
+                        <img alt="" src="images/assets/team/avatar.png" alt="shell lead avatar">
+                    </div>
+                    <div class="info">
+                        <div class="title">
+                          <h5>Name goes here</h5>
+                          <p>Co-organizer</p>
                         </div>
-                    </blockquote>
-                </div>
-            </div>
+                        <div class="desc">Mobile and Web developer</div>
+                        <div class="desc">Open source enthusiast</div>
+                        <div class="desc">Community mentor</div>
+                    </div>
+                    <div class="bottom">
+                    <ul class="social-list__inline mt-10">
+                      <li>
+                          <a href="https://twitter.com/ProfileName">
+                              <i class="fab fa-twitter"></i>
+                          </a>
+                      </li>
+                      <li>
+                          <a href="https://github.com/ProfileName">
+                              <i class="fab fa-github"></i>
+                          </a>
+                      </li>
+                      <li>
+                          <a href="https://www.facebook.com/ProfileName">
+                              <i class="fab fa-facebook"></i>
+                          </a>
+                      </li>
+                      <li>
+                          <a href="https://www.linkedin.com/in/ProfileName">
+                              <i class="fab fa-linkedin"></i>
+                          </a>
+                      </li>
+                    </ul>
+                  </div>
+                  </div>
+              </div>
+          </div>
+
+          <div class="carousel-item col-md-4 col-15">
+              <div class="card event-card">
+                <div class="card hovercard">
+                    <div class="cardheader">
+
+                    </div>
+                    <div class="avatar">
+                        <img alt="" src="images/assets/team/avatar.png" alt="shell lead avatar">
+                    </div>
+                    <div class="info">
+                        <div class="title">
+                            <h5>Name goes here</h5>
+                            <p>Co-organizer</p>
+                        </div>
+                        <div class="desc">Mobile and Web developer</div>
+                        <div class="desc">Open source enthusiast</div>
+                        <div class="desc">Community mentor</div>
+                    </div>
+                    <div class="bottom">
+                    <ul class="social-list__inline mt-10">
+                        <li>
+                            <a href="https://twitter.com/ProfileName">
+                                <i class="fab fa-twitter"></i>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://github.com/ProfileName">
+                                <i class="fab fa-github"></i>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://www.facebook.com/ProfileName">
+                                <i class="fab fa-facebook"></i>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://www.linkedin.com/in/ProfileName">
+                                <i class="fab fa-linkedin"></i>
+                            </a>
+                        </li>
+                    </ul>
+                  </div>
+                  </div>
+              </div>
+          </div>
+
+          <div class="carousel-item col-md-4 col-15">
+              <div class="card event-card">
+                <div class="card hovercard">
+                    <div class="cardheader">
+
+                    </div>
+                    <div class="avatar">
+                        <img alt="" src="images/assets/team/avatar.png" alt="shell lead avatar">
+                    </div>
+                    <div class="info">
+                        <div class="title">
+                          <h5>Name goes here</h5>
+                          <p>Volunteer</p>
+                        </div>
+                        <div class="desc">Graphic Design</div>
+                        <div class="desc">Storyteller</div>
+                        <div class="desc">Writer</div>
+                    </div>
+                    <div class="bottom">
+                    <ul class="social-list__inline mt-10">
+                      <li>
+                          <a href="https://twitter.com/ProfileName">
+                              <i class="fab fa-twitter"></i>
+                          </a>
+                      </li>
+                      <li>
+                          <a href="https://github.com/ProfileName">
+                              <i class="fab fa-github"></i>
+                          </a>
+                      </li>
+                      <li>
+                          <a href="https://www.facebook.com/ProfileName">
+                              <i class="fab fa-facebook"></i>
+                          </a>
+                      </li>
+                      <li>
+                          <a href="https://www.linkedin.com/in/ProfileName">
+                              <i class="fab fa-linkedin"></i>
+                          </a>
+                      </li>
+                    </ul>
+                  </div>
+                  </div>
+              </div>
+          </div>
+
+          <div class="carousel-item col-md-4 col-15">
+              <div class="card event-card">
+                <div class="card hovercard">
+                    <div class="cardheader">
+
+                    </div>
+                    <div class="avatar">
+                        <img alt="" src="images/assets/team/avatar.png" alt="shell lead avatar">
+                    </div>
+                    <div class="info">
+                        <div class="title">
+                          <h5>Name goes here</h5>
+                          <p>Volunteer</p>
+                        </div>
+                        <div class="desc">Web design</div>
+                        <div class="desc">Game development</div>
+                        <div class="desc">Anime lover</div>
+                    </div>
+                    <div class="bottom">
+                    <ul class="social-list__inline mt-10">
+                      <li>
+                          <a href="https://twitter.com/ProfileName">
+                              <i class="fab fa-twitter"></i>
+                          </a>
+                      </li>
+                      <li>
+                          <a href="https://github.com/ProfileName">
+                              <i class="fab fa-github"></i>
+                          </a>
+                      </li>
+                      <li>
+                          <a href="https://www.facebook.com/ProfileName">
+                              <i class="fab fa-facebook"></i>
+                          </a>
+                      </li>
+                      <li>
+                          <a href="https://www.linkedin.com/in/ProfileName">
+                              <i class="fab fa-linkedin"></i>
+                          </a>
+                      </li>
+                    </ul>
+                  </div>
+                  </div>
+              </div>
+          </div>
+
+          <div class="carousel-item col-md-4 col-15">
+              <div class="card event-card">
+                <div class="card hovercard">
+                    <div class="cardheader">
+
+                    </div>
+                    <div class="avatar">
+                        <img alt="" src="images/assets/team/avatar.png" alt="shell lead avatar">
+                    </div>
+                    <div class="info">
+                        <div class="title">
+                            <h5>Name goes here</h5>
+                            <p>DSC Faculty Adviser</p>
+                        </div>
+                        <div class="desc">Cryptocurrency Control</div>
+                        <div class="desc">Bioinformatics</div>
+                        <div class="desc">IOT</div>
+                    </div>
+                    <div class="bottom">
+                    <ul class="social-list__inline mt-10">
+                        <li>
+                            <a href="https://twitter.com/ProfileName">
+                                <i class="fab fa-twitter"></i>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://github.com/ProfileName">
+                                <i class="fab fa-github"></i>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://www.facebook.com/ProfileName">
+                                <i class="fab fa-facebook"></i>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://www.linkedin.com/in/ProfileName">
+                                <i class="fab fa-linkedin"></i>
+                            </a>
+                        </li>
+                    </ul>
+                  </div>
+                  </div>
+              </div>
+          </div>
+          </div>
+          <a class="carousel-control-prev" href="#carouselExample" role="button" data-slide="prev">
+            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+            <span class="sr-only">Previous</span>
+        </a>
+        <a class="carousel-control-next text-faded" href="#carouselExample" role="button" data-slide="next">
+            <span class="carousel-control-next-icon" aria-hidden="true"></span>
+            <span class="sr-only">Next</span>
+        </a>
         </div>
+    </div>
     </div>
 </section>
 

--- a/js/custom.js
+++ b/js/custom.js
@@ -73,42 +73,28 @@ $(document).ready(function(){
   /*====================================================*/
   /* team SLIDER                                 */
   /*====================================================*/
+    $('#carouselExample').on('slide.bs.carousel', function (e) {
 
 
-  var $ClientsSlider = $('.team-slider');
-  if ($ClientsSlider.length > 0) {
-    $ClientsSlider.owlCarousel({
-      loop: true,
-      center: true,
-      margin: 0,
-      items: 1,
-      nav: false,
-      dots: true,
-      lazyLoad: true,
-      dotsContainer: '.dots'
-    })
-    $('.owl-dot').on('click', function() {
-      $(this).addClass('active').siblings().removeClass('active');
-      $ClientsSlider.trigger('to.owl.carousel', [$(this).index(), 300]);
-    });
-  }
+      var $e = $(e.relatedTarget);
+      var idx = $e.index();
+      var itemsPerSlide = 3;
+      var totalItems = $('.carousel-item').length;
 
-  var swiper = new Swiper('.screen-slider', {
-    direction: 'horizontal',
-    slidesPerView: 1,
-    spaceBetween: 1,
-    parallax: true,
-    breakpoints: {
-      480: {
-        slidesPerView: 1,
-        spaceBetween: 40
+      if (idx >= totalItems-(itemsPerSlide-1)) {
+          var it = itemsPerSlide - (totalItems - idx);
+          for (var i=0; i<it; i++) {
+              // append slides to end
+              if (e.direction=="left") {
+                  $('.carousel-item').eq(i).appendTo('.carousel-inner');
+              }
+              else {
+                  $('.carousel-item').eq(0).appendTo('.carousel-inner');
+              }
+          }
       }
-    },
-    navigation: {
-      nextEl: '.swiper-button-next',
-      prevEl: '.swiper-button-prev',
-    }
   });
+
 
   /*====================================================*/
   /* TABS INIT                                   */


### PR DESCRIPTION
- Support for team cards with a short description and social media handles. Allocations for a team of six.
- Integrated the new carousel: displays 3 cards at a time on the website and one card at a time on mobile. Scroll to the left or right.
![deepinscreenshot_select-area_20190206124252](https://user-images.githubusercontent.com/18654569/52332880-eb781380-2a0c-11e9-939b-c670f366489e.png)

![deepinscreenshot_select-area_20190206124338](https://user-images.githubusercontent.com/18654569/52332888-f03cc780-2a0c-11e9-91bb-6032c77b9525.png)


